### PR TITLE
fix: erts now runs in a libmicrokitco co-thread

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     # the fs protocol definitions from the input's source tree.
     #
     # git+https URLs instead of the github: fetcher because this network
-    # blocks api.github.com; plain git over https to github.com works.
+    # blocks api.github.com. Plain git over https to github.com works.
     lionsos = {
       url = "git+https://github.com/au-ts/lionsos";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -66,7 +66,7 @@
     # submodules), so the reference-stack libc + drivers have no sDDF to build
     # against. We pin sDDF to the exact gitlink the locked lionsos rev
     # references and let lionsos-src populate dep/sddf from inputs.sddf. The
-    # sddf flake exposes only devShells; we use its source tree and mirror its
+    # sddf flake exposes only devShells. We use its source tree and mirror its
     # llvm/clang toolchain choice (llvmPackages_18) for the driver builds.
     sddf = {
       url = "git+https://github.com/au-ts/sddf?ref=refs/heads/main&rev=d1f5252ea64edab6087552eb4220e23c019c2fbe";
@@ -76,7 +76,7 @@
     };
 
     # libmicrokitco: the LionsOS cooperative cothread library. Another empty
-    # lionsos submodule; pinned to the gitlink the locked lionsos references.
+    # lionsos submodule, pinned to the gitlink the locked lionsos references.
     # Needed by the fat fs_server and by the ERTS threading layer.
     # - ERTS helper threads run as cothreads).
     # - lionsos-src populates dep/libmicrokitco from this input.
@@ -107,7 +107,7 @@
   };
 
   # The build pipeline lives in modules/, one flake-parts module per
-  # concern; modules share derivations through config.packages.* and
+  # concern. Modules share derivations through config.packages.* and
   # non-derivation context (board names, toolchains, the zig2nix env)
   # through the `chryso` module argument defined in toolchain.nix:
   #

--- a/nix/refstack.mk
+++ b/nix/refstack.mk
@@ -16,7 +16,7 @@
 #
 # Produces, in $(BUILD_DIR): libc/lib/libc.a, libc/include/, and the board DTB.
 # The sDDF driver/virtualiser PDs and libmicrokitco are built by the root
-# build.zig now; their .mk includes below remain only so their rules/vars
+# build.zig now. Their .mk includes below remain only so their rules/vars
 # parse, their targets are no longer requested by `all`.
 
 MICROKIT_CONFIG ?= debug

--- a/src/runtime/bringup.c
+++ b/src/runtime/bringup.c
@@ -62,18 +62,37 @@ extern timer_client_config_t timer_config;
  * the poll-callback-nulled copy main.c hands libc_init. The socket-aware epoll
  * below queries readiness through it. */
 extern libc_socket_config_t socket_config;
-/* Advances the linked lwIP stack (RX/TX). Defined in main.c, called from the
- * poll/sleep stubs so lwIP progresses while ERTS spins (notified() is dead once
- * erl_start runs). */
+/* Advances the linked lwIP stack (RX/TX). Defined in main.c, still pumped from
+ * the poll/sleep stubs as a backstop. The primary driver is now notified(),
+ * which fires again because init() returns to the Microkit event loop. */
 extern void beam_net_pump(void);
+
+/* Cothread idle plumbing (process.c). The poll/sleep stubs park on the shared
+ * idle semaphore instead of busy-yielding, so the PD idles at ~0% CPU.
+ * thread_io_wait() blocks until notified() pulses (any channel) or a waker
+ * calls thread_io_wake(). Callers re-check their predicate in a loop.
+ * thread_park_forever() blocks with no wakeup (dead reads). */
+extern void thread_io_wait(void);
+extern void thread_io_wake(void);
+extern void thread_park_forever(void);
+
+/* Timer multiplexer (main.c): arm the single sDDF timeout slot for the nearest
+ * pending absolute monotonic deadline. Timed waits use it so a wakeup pulse is
+ * guaranteed to arrive by their deadline. */
+extern void beam_timer_arm(uint64_t deadline_ns);
 
 #define SERIAL_RX_CH 1
 
 /* Discard sink / EOF source for the synthetic fds below (pipe write end,
- * timerfd, socketpair): writes are discarded, reads return EOF. */
+ * timerfd, socketpair): writes are discarded, reads return EOF. A write DOES
+ * pulse the idle waiters: ERTS wakes its pollset by writing a byte to its
+ * self-pipe, and the poller parked in epoll_pwait/ppoll must wake and return
+ * so ERTS re-evaluates its pollset/timeout (on Linux the kernel does this via
+ * the pipe becoming readable, here the pulse is the wakeup). */
 static ssize_t devnull_write(const void *data, size_t count, int fd) {
   (void)data;
   (void)fd;
+  thread_io_wake();
   return (ssize_t)count;
 }
 
@@ -98,9 +117,12 @@ static ssize_t empty_read(void *data, size_t count, int fd) {
   if (e != NULL && (e->flags & O_NONBLOCK)) {
     return -EAGAIN;
   }
-  for (;;) {
-    microkit_cothread_yield();
-  }
+  /* No data will ever arrive on this fd (ERTS's signal-dispatcher blocks here
+   * reading the signal pipe, we have no OS signals). Park forever consuming no
+   * CPU instead of yielding, so this cothread doesn't keep the PD from idling.
+   */
+  thread_park_forever();
+  return 0; /* unreachable */
 }
 
 /* Echo a keystroke back to the console. QEMU's -serial mon:stdio raw-mode host
@@ -237,11 +259,17 @@ static long bringup_zero(va_list ap) {
 }
 
 /* Cothread-aware futex. ERTS's low-level thread-event primitive (ethr_event)
- * uses futex directly and treats ENOSYS as fatal. Under cooperative
- * cothreads, FUTEX_WAIT yields (letting the waker cothread run) until the
- * word changes or a bounded number of rounds elapse (spurious return, ERTS
- * re-checks its event flag). FUTEX_WAKE is a no-op: waiters observe the word
- * when they next run. */
+ * uses futex directly and treats ENOSYS as fatal. FUTEX_WAIT parks the calling
+ * cothread on the shared idle semaphore (thread_io_wait) until the word
+ * changes. Because cothreads are cooperative (no preemption between the compare
+ * and the park), there is no lost-wakeup window. FUTEX_WAKE pulses the idle
+ * semaphore (thread_io_wake) so a parked waiter re-checks its word. Waiters may
+ * also be woken spuriously by notified() pulses, they simply re-compare and
+ * re-park, which is why the PD can idle at ~0% CPU here instead of spinning.
+ *
+ * A timed FUTEX_WAIT (timeout != NULL) keeps a bounded yield loop: the deadline
+ * must be honoured, and mapping arbitrary futex timeouts onto the sDDF timer is
+ * not worth it, timed waits are transient (active work), not the idle path. */
 #define FUTEX_WAIT_OP 0
 #define FUTEX_WAKE_OP 1
 #define FUTEX_WAIT_BITSET_OP 9
@@ -251,37 +279,33 @@ static long bringup_futex(va_list ap) {
   int *uaddr = va_arg(ap, int *);
   int op = va_arg(ap, int);
   int val = va_arg(ap, int);
+  const struct timespec *timeout = va_arg(ap, const struct timespec *);
   int cmd = op & 0x7f; /* strip FUTEX_PRIVATE_FLAG / FUTEX_CLOCK_REALTIME */
 
   if (cmd == FUTEX_WAKE_OP || cmd == FUTEX_WAKE_BITSET_OP) {
+    thread_io_wake();
     return 0;
   }
   /* FUTEX_WAIT / FUTEX_WAIT_BITSET */
   if (__atomic_load_n(uaddr, __ATOMIC_ACQUIRE) != val) {
     return -EAGAIN;
   }
-  /* DIAG wait-latency tracing (uncomment sparingly: the print itself floods
-   * the serial path and distorts the timing being measured):
-   * uint64_t f0 = sddf_timer_time_now(timer_config.driver_id); */
-  for (int i = 0; i < 4096; i++) {
-    microkit_cothread_yield();
-    if (__atomic_load_n(uaddr, __ATOMIC_ACQUIRE) != val) {
-      // uint64_t f1 = sddf_timer_time_now(timer_config.driver_id);
-      // if (f1 - f0 > 100000000ull) {
-      //   printf("DIAG|%lu|futex woke after %lums\n",
-      //          (unsigned long)(f1 / 1000000ull),
-      //          (unsigned long)((f1 - f0) / 1000000ull));
-      // }
-      return 0;
+  if (timeout != NULL) {
+    /* Timed wait: bounded yield, return spuriously so ERTS re-checks and
+     * re-arms. Not the idle path. */
+    for (int i = 0; i < 4096; i++) {
+      microkit_cothread_yield();
+      if (__atomic_load_n(uaddr, __ATOMIC_ACQUIRE) != val) {
+        return 0;
+      }
     }
+    return 0;
   }
-  // uint64_t f2 = sddf_timer_time_now(timer_config.driver_id);
-  // if (f2 - f0 > 100000000ull) {
-  //   printf("DIAG|%lu|futex spurious after %lums\n",
-  //          (unsigned long)(f2 / 1000000ull),
-  //          (unsigned long)((f2 - f0) / 1000000ull));
-  // }
-  return 0; /* spurious, the caller re-checks */
+  /* Untimed wait (the idle path): park until the word changes. */
+  while (__atomic_load_n(uaddr, __ATOMIC_ACQUIRE) == val) {
+    thread_io_wait();
+  }
+  return 0;
 }
 
 /* musl's _Exit() calls exit_group then loops on exit, neither is implemented
@@ -321,13 +345,13 @@ static long bringup_clock_getres(va_list ap) {
 }
 
 /* clock_nanosleep: a real timed sleep (musl's nanosleep/usleep/sleep all route
- * here via SYS_clock_nanosleep). The old stub returned immediately, making
- * those calls no-ops. We busy-poll the sDDF monotonic clock and yield to the
- * cothread scheduler until the deadline -- the SAME pattern process.c's
- * pthread_cond_timedwait uses. We deliberately do NOT block on a notification
- * (microkit_cothread_wait_on_channel): erl_start runs on the root cothread and
- * never returns, so notified()/recv_ntfn never fire and such a wait would hang
- * forever (the whole PD works by busy-polling shared memory). */
+ * here via SYS_clock_nanosleep). Arms the sDDF timer for the remaining interval
+ * and parks the cothread on the idle semaphore, re-checking the monotonic clock
+ * each wake. This blocks instead of busy-polling: notified(timer) pulses the
+ * idle waiters when the timeout fires, so the PD idles at ~0% CPU during a
+ * sleep. (This is now safe because init() returns to the Microkit event loop,
+ * so notified()/recv_ntfn actually fire, the reason the old stub had to
+ * busy-poll shared memory.) */
 static long bringup_clock_nanosleep(va_list ap) {
   long clockid = va_arg(ap, long);
   int flags = va_arg(ap, int);
@@ -343,7 +367,7 @@ static long bringup_clock_nanosleep(va_list ap) {
   uint64_t reqns =
       (uint64_t)req->tv_sec * 1000000000ull + (uint64_t)req->tv_nsec;
   /* An absolute CLOCK_REALTIME deadline lives on the epoch-offset timeline
-   * (see bringup_clock_gettime); the sDDF timer is monotonic-native, so shift
+   * (see bringup_clock_gettime). The sDDF timer is monotonic-native, so shift
    * such a deadline back before comparing or it is ~56 years away and this
    * sleep never returns. Relative sleeps and monotonic deadlines pass through
    * unchanged. */
@@ -359,10 +383,11 @@ static long bringup_clock_nanosleep(va_list ap) {
   //          (unsigned long)((target - now0) / 1000000ull));
   // }
   while (sddf_timer_time_now(ch) < target) {
-    /* Keep lwIP advancing during the sleep so TCP timers/RX don't stall while
-     * a scheduler cothread is parked here. */
-    beam_net_pump();
-    microkit_cothread_yield();
+    /* Arm the timer for the deadline and park until a pulse (the timer fire,
+     * or any other notification, then we re-check and re-arm). notified()
+     * pumps lwIP, so the network keeps advancing while we sleep. */
+    beam_timer_arm(target);
+    thread_io_wait();
   }
   if (rem != NULL && !(flags & TIMER_ABSTIME)) {
     rem->tv_sec = 0;
@@ -489,33 +514,10 @@ static long bringup_epoll_ctl(va_list ap) {
   return 0;
 }
 
-/* epoll_pwait: scan registered fds for readiness. fd 0 (stdin) is readable when
- * the serial RX queue has data, socket fds report readiness from tcp.c. This is
- * the scheduler's hot idle loop, so it also pumps lwIP (beam_net_pump), under
- * ERTS that is the only thing advancing the network. Return matching events
- * with the caller's registered data, yield when nothing is ready.
- *
- * When timeout > 0 and no events are ready, this stub sleeps for a fraction of
- * the requested timeout (capped at 10 ms per round) to give QEMU's main loop a
- * chance to poll slirp's hostfwd listen fds. Without this sleep, the vCPU
- * busy-spins nonstop, QEMU's main loop is starved, and host→guest TCP SYNs
- * (injected by slirp's hostfwd accept handler, which runs in QEMU's main loop)
- * never reach the virtio-net device. Guest→host traffic (DHCP, outgoing
- * connect) is unaffected because it originates in the vCPU thread and the
- * response is delivered synchronously via virtio MMIO. */
-static long bringup_epoll_pwait(va_list ap) {
-  int epfd = va_arg(ap, int);
-  struct epoll_event *events = va_arg(ap, struct epoll_event *);
-  int maxevents = va_arg(ap, int);
-  int timeout = va_arg(ap, int);
-  (void)epfd;
-
-  if (events == NULL || maxevents <= 0) {
-    return -EINVAL;
-  }
-
-  beam_net_pump();
-
+/* Scan the epoll table for ready fds: fd 0 (stdin) is readable when the serial
+ * RX queue has data, socket fds report readiness from tcp.c. Fills events with
+ * the caller's registered data verbatim (ERTS keys I/O sources off it). */
+static int epoll_scan(struct epoll_event *events, int maxevents) {
   int n = 0;
   for (int i = 0; i < EPOLL_MAX_FDS && n < maxevents; i++) {
     if (!epoll_table[i].active || !epoll_table[i].armed) {
@@ -544,10 +546,10 @@ static long bringup_epoll_pwait(va_list ap) {
     revents &= (epoll_table[i].ev.events | EPOLLERR | EPOLLHUP);
     if (revents) {
       // if (epoll_table[i].is_sock) {
-      //   printf("DIAG|%lu|epoll deliver sock=%d ev=%x to=%d\n",
+      //   printf("DIAG|%lu|epoll deliver sock=%d ev=%x\n",
       //          (unsigned long)(sddf_timer_time_now(timer_config.driver_id) /
       //                          1000000ull),
-      //          epoll_table[i].sock_handle, revents, timeout);
+      //          epoll_table[i].sock_handle, revents);
       // }
       events[n].events = revents;
       events[n].data = epoll_table[i].ev.data;
@@ -560,27 +562,43 @@ static long bringup_epoll_pwait(va_list ap) {
       }
     }
   }
+  return n;
+}
 
-  if (n == 0) {
-    /* No events ready: sleep a fraction of the requested timeout (or a
-     * minimum 100 ms if timeout <= 0) to give QEMU's main loop time to poll
-     * slirp's hostfwd listen fd. ERTS passes timeout=-1 when idle, on a
-     * real OS this blocks the thread and the CPU goes idle. Without this
-     * sleep the vCPU busy-spins nonstop, QEMU's main loop is starved, and
-     * host->guest TCP SYNs (injected by slirp's hostfwd accept handler,
-     * which runs in QEMU's main loop) never reach the virtio-net device.
-     * The sleep busy-polls the sDDF monotonic clock and pumps lwIP, so the
-     * network still progresses even while the scheduler "blocks". */
-    struct timespec ts;
-    long sleep_ms = timeout > 0 ? (timeout < 20 ? timeout : 20) : 20;
-    ts.tv_sec = 0;
-    ts.tv_nsec = sleep_ms * 1000000L;
-    unsigned ch = timer_config.driver_id;
-    uint64_t target = sddf_timer_time_now(ch) + (uint64_t)ts.tv_nsec;
-    while (sddf_timer_time_now(ch) < target) {
-      beam_net_pump();
-      microkit_cothread_yield();
+/* epoll_pwait: ERTS's kernel-poll idle wait. If nothing is ready, park on the
+ * idle semaphore (arming the timer mux for a finite timeout first) and rescan
+ * after ONE pulse, then return, possibly with 0 events before the timeout
+ * expires. Returning early-and-empty is deliberate, not sloppy: ERTS updates
+ * its pollset/timeout between calls and signals such changes by writing its
+ * wakeup pipe (devnull_write -> thread_io_wake). Looping here until the
+ * original deadline would miss e.g. a shorter timer set after we parked. ERTS
+ * treats a 0-return as a timeout and simply re-evaluates and re-calls.
+ *
+ * This used to be the scheduler's hot busy-loop (and needed a busy-sleep hack
+ * so the starved QEMU main loop could deliver slirp's hostfwd SYNs). With the
+ * PD genuinely blocking in seL4_Recv, QEMU's main loop runs freely. */
+static long bringup_epoll_pwait(va_list ap) {
+  int epfd = va_arg(ap, int);
+  struct epoll_event *events = va_arg(ap, struct epoll_event *);
+  int maxevents = va_arg(ap, int);
+  int timeout = va_arg(ap, int);
+  (void)epfd;
+
+  if (events == NULL || maxevents <= 0) {
+    return -EINVAL;
+  }
+
+  beam_net_pump();
+
+  int n = epoll_scan(events, maxevents);
+  if (n == 0 && timeout != 0) {
+    if (timeout > 0) {
+      beam_timer_arm(sddf_timer_time_now(timer_config.driver_id) +
+                     (uint64_t)timeout * 1000000ull);
     }
+    thread_io_wait();
+    beam_net_pump();
+    n = epoll_scan(events, maxevents);
   }
 
   /* Always yield so the dirty-IO scheduler cothread (which performs the
@@ -589,21 +607,9 @@ static long bringup_epoll_pwait(va_list ap) {
   return n;
 }
 
-/* ppoll: ERTS's scheduler polls for I/O when idle. Returning immediately would
- * busy-spin the scheduler cothread and starve the helper cothreads (aux, poll,
- * dirty-I/O), stalling boot. Yield first so the cothread scheduler runs the
- * others, then report no ready events. Also pumps lwIP (a backstop for the
- * epoll_pwait pump: ERTS also polls via ppoll). */
-static long bringup_poll_yield(va_list ap) {
-  struct pollfd *fds = va_arg(ap, struct pollfd *);
-  nfds_t nfds = va_arg(ap, nfds_t);
-
-  beam_net_pump();
-
-  /* Report real readiness: socket fds from tcp.c's socket_config, stdin from
-   * the serial RX queue. Returning 0 for a ready socket would leave ERTS's
-   * fallback pollset blind (and 0 on an infinite timeout is a spec violation
-   * ERTS responds to by re-calling in a hot loop). */
+/* Scan a pollfd array for real readiness: socket fds from tcp.c's
+ * socket_config, stdin from the serial RX queue. */
+static int poll_scan(struct pollfd *fds, nfds_t nfds) {
   int ready = 0;
   for (nfds_t i = 0; i < nfds && fds != NULL; i++) {
     fds[i].revents = 0;
@@ -635,6 +641,35 @@ static long bringup_poll_yield(va_list ap) {
       ready++;
     }
   }
+  return ready;
+}
+
+/* ppoll: ERTS's fallback pollset thread ppolls its wakeup pipe forever, and
+ * schedulers use it as a poll backstop. If nothing is ready, park until ONE
+ * pulse (arming the timer mux for a finite timeout), rescan and return,
+ * possibly 0 before the deadline, for the same reason as epoll_pwait above:
+ * a wakeup-pipe write (devnull_write pulses) must make this return so ERTS
+ * re-evaluates its pollset. The old stub returned 0 immediately after a
+ * yield, which kept the fallback poll thread hot-looping forever. */
+static long bringup_poll_yield(va_list ap) {
+  struct pollfd *fds = va_arg(ap, struct pollfd *);
+  nfds_t nfds = va_arg(ap, nfds_t);
+  const struct timespec *tmo = va_arg(ap, const struct timespec *);
+
+  beam_net_pump();
+
+  int ready = poll_scan(fds, nfds);
+  bool zero_timeout = tmo != NULL && tmo->tv_sec == 0 && tmo->tv_nsec == 0;
+  if (ready == 0 && !zero_timeout) {
+    if (tmo != NULL) {
+      beam_timer_arm(sddf_timer_time_now(timer_config.driver_id) +
+                     (uint64_t)tmo->tv_sec * 1000000000ull +
+                     (uint64_t)tmo->tv_nsec);
+    }
+    thread_io_wait();
+    beam_net_pump();
+    ready = poll_scan(fds, nfds);
+  }
 
   // if (ready) {
   //   printf("DIAG|%lu|ppoll ready=%d fd0=%d rev0=%x\n",
@@ -648,7 +683,9 @@ static long bringup_poll_yield(va_list ap) {
 
 /* pselect6: select()/pselect6 syscall, parse fd_sets and report which fds
  * are ready. ERTS doesn't use this for stdin (it uses epoll), but other tools
- * (e.g. the shell's select() timeout sleeps) may call it. */
+ * (e.g. the shell's select() timeout sleeps) may call it. Only stdin (fd 0)
+ * readability is supported. If nothing is ready, park until one pulse (arming
+ * the timer mux for a finite timeout) and rescan, like epoll_pwait/ppoll. */
 static long bringup_pselect6(va_list ap) {
   int nfds = va_arg(ap, int);
   fd_set *readfds = va_arg(ap, fd_set *);
@@ -657,39 +694,46 @@ static long bringup_pselect6(va_list ap) {
   const struct timespec *timeout = va_arg(ap, const struct timespec *);
   const sigset_t *sigmask = va_arg(ap, const sigset_t *);
 
-  (void)timeout;
   (void)sigmask;
 
   if (nfds < 0 || nfds > FD_SETSIZE) {
     return -EINVAL;
   }
 
-  int ready = 0;
+  bool want_stdin = readfds != NULL && FD_ISSET(0, readfds);
+  bool zero_timeout =
+      timeout != NULL && timeout->tv_sec == 0 && timeout->tv_nsec == 0;
 
-  /* Check stdin (fd 0) if it's in the readfds set */
-  if (readfds != NULL && FD_ISSET(0, readfds)) {
-    if (serial_queue_length_consumer(&serial_rx_queue_handle) > 0) {
-      /* Keep fd 0 set - data is ready */
-      ready++;
-    } else {
-      /* Clear fd 0 - no data ready */
-      FD_CLR(0, readfds);
+  int ready =
+      (want_stdin && serial_queue_length_consumer(&serial_rx_queue_handle) > 0)
+          ? 1
+          : 0;
+  if (ready == 0 && !zero_timeout) {
+    beam_net_pump();
+    if (timeout != NULL) {
+      beam_timer_arm(sddf_timer_time_now(timer_config.driver_id) +
+                     (uint64_t)timeout->tv_sec * 1000000000ull +
+                     (uint64_t)timeout->tv_nsec);
+    }
+    thread_io_wait();
+    if (want_stdin &&
+        serial_queue_length_consumer(&serial_rx_queue_handle) > 0) {
+      ready = 1;
     }
   }
 
+  if (readfds != NULL) {
+    FD_ZERO(readfds);
+    if (ready) {
+      FD_SET(0, readfds);
+    }
+  }
   /* Clear write and except sets (not implemented) */
   if (writefds != NULL) {
     FD_ZERO(writefds);
   }
   if (exceptfds != NULL) {
     FD_ZERO(exceptfds);
-  }
-
-  /* If nothing ready, pump lwIP and yield to other cothreads before returning
-   */
-  if (ready == 0) {
-    beam_net_pump();
-    microkit_cothread_yield();
   }
 
   return ready;
@@ -730,7 +774,7 @@ static long bringup_uname(va_list ap) {
   return 0;
 }
 
-/* ---- Real entropy (issue 0.3.0-rng): getrandom / clock_gettime / openat.
+/* ---- Real entropy: getrandom / clock_gettime / openat.
  *
  * libc_init (posix.c) and libc_init_file (file.c) claim these three slots
  * before bringup_register_syscalls runs, and libc_define_syscall asserts the
@@ -746,7 +790,7 @@ static muslcsys_syscall_t old_openat;
 
 /* RNG_REALTIME_BASE_EPOCH (rng.h): a sane 2026 base epoch so CLOCK_REALTIME is
  * roughly correct (future TLS cert validity, log timestamps) instead of
- * starting near 0. The real fix (RTC/NTP) is a separate future issue; here we
+ * starting near 0. The real fix (RTC/NTP) is a separate future issue. Here we
  * only need it non-zero and per-boot-varying. */
 
 /* getrandom(2): fill the caller's buffer from the DRBG. Replaces LionsOS's
@@ -862,8 +906,8 @@ void bringup_register_syscalls(void) {
   libc_define_syscall(SYS_epoll_pwait, bringup_epoll_pwait);
   libc_define_syscall(SYS_pselect6, bringup_pselect6);
   /* ppoll stays with bringup (not sock.c): main.c nulls sock.c's poll callbacks
-   * so sock.c does not claim __NR_ppoll, keeping the cothread-yielding stub
-   * that ERTS boot needs. */
+   * so sock.c does not claim __NR_ppoll, keeping the cothread-blocking stub
+   * that ERTS boot needs (sock.c's sys_ppoll neither yields nor parks). */
   libc_define_syscall(SYS_ppoll, bringup_poll_yield);
   libc_define_syscall(SYS_pipe2, bringup_pipe2);
   libc_define_syscall(SYS_timerfd_create, bringup_timerfd_create);

--- a/src/runtime/lwip_include/lwipopts.h
+++ b/src/runtime/lwip_include/lwipopts.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Vendored from LionsOS examples/posix_test/lwip_include/lwipopts.h. This is
- * the per-client lwIP build configuration for beam_server's linked lwIP stack;
- * each LionsOS lwIP client keeps its own copy (the lib_sddf_lwip build picks it
+ * the per-client lwIP build configuration for beam_server's linked lwIP stack.
+ * Each LionsOS lwIP client keeps its own copy (the lib_sddf_lwip build picks it
  * up via the include path). Keep it in sync with the reference stack.
  */
 

--- a/src/runtime/main.c
+++ b/src/runtime/main.c
@@ -76,9 +76,12 @@ static bool net_enabled;
 static bool lwip_up;
 static bool dhcp_ready;
 
-/* Period of the lwIP service timer (RX poll + lwIP timeouts), matching the
- * LionsOS posix_test client. */
-#define NET_TIMEOUT (1 * NS_IN_MS)
+/* Period of the lwIP service timer (lwIP timeout processing, RX is driven by
+ * the net-RX channel notification, not this tick). 100 ms is ample for lwIP's
+ * cyclic timers (DHCP fine timer 500 ms, TCP timers 250 ms) and keeps the idle
+ * wakeup rate at ~10/s so the PD sits near 0% CPU. The LionsOS posix_test
+ * client uses 1 ms, but it busy-polls RX off this tick. We do not. */
+#define NET_TIMEOUT (100 * NS_IN_MS)
 
 /* beam_heap region base, patched by the Microkit tool at synthesis time
  * (setvar_vaddr). Handed to libc_init() as the malloc arena, which
@@ -94,12 +97,36 @@ extern void bringup_register_syscalls(void);
 extern void rng_init(void);
 extern void thread_init(void);
 extern void thread_notified(microkit_channel ch);
+extern void thread_run_cothreads(void);
+extern void thread_io_wake(void);
+extern void thread_park_forever(void);
+
+/* ---- Timer multiplexer ----
+ *
+ * The PD has ONE sDDF timeout slot (a new sddf_timer_set_timeout replaces the
+ * pending one), but several consumers now want deadlines: the lwIP service
+ * tick, clock_nanosleep, timed epoll_pwait/ppoll/pselect6 and
+ * pthread_cond_timedwait. beam_timer_arm keeps the slot armed for the NEAREST
+ * pending absolute deadline (monotonic ns). When the timeout fires, notified()
+ * clears the slot and pulses the idle waiters (thread_io_wake). Each timed
+ * waiter re-checks its own deadline and re-arms if it still has time left, so
+ * a longer deadline armed "over" a shorter one is never lost. */
+static uint64_t beam_timer_deadline; /* armed absolute deadline, 0 = none */
+
+void beam_timer_arm(uint64_t deadline_ns) {
+  uint64_t now = sddf_timer_time_now(timer_config.driver_id);
+  if (deadline_ns <= now) {
+    deadline_ns = now + 1; /* already due: fire immediately */
+  }
+  if (beam_timer_deadline == 0 || deadline_ns < beam_timer_deadline) {
+    beam_timer_deadline = deadline_ns;
+    sddf_timer_set_timeout(timer_config.driver_id, deadline_ns - now);
+  }
+}
 
 /* The libc fs path spins here until fatfs records the completion of an fs
- * command. erl_start never returns to the Microkit event loop, so notified()
- * never fires and we cannot block on the fs channel (the reference clients park
- * the cothread and let notified() drain), instead we drain the completion queue
- * directly (fatfs, a higher-priority PD, fills it via seL4 preemption).
+ * command. We drain the completion queue directly (fatfs, a higher-priority PD,
+ * fills it via seL4 preemption) rather than parking on the fs channel.
  *
  * Crucially this does NOT yield to other cothreads: yielding lets an ERTS
  * helper cothread issue a reentrant fs read mid-command, and the two
@@ -132,18 +159,20 @@ static void net_init(void) {
                  netif_status_callback, NULL, NULL, NULL);
   lwip_up = true;
   sddf_lwip_maybe_notify();
-  sddf_timer_set_timeout(timer_config.driver_id, NET_TIMEOUT);
+  beam_timer_arm(sddf_timer_time_now(timer_config.driver_id) + NET_TIMEOUT);
 }
 
 /* Deliver Microkit's pending deferred notification immediately, mirroring the
  * libmicrokit handler epilogue (seL4_Send on the stashed signal cap/msg that
  * microkit_deferred_notify set). sddf_lwip_maybe_notify() defers the RX/TX
  * virtualiser signal into Microkit's single-slot pending-signal, which the
- * epilogue only flushes when the PD returns from notified()/init(). Under ERTS
- * erl_start() never returns, so without this flush the deferred signal is
- * stashed but never delivered: net_virt_tx is never woken and the TX queue
- * (DHCP DISCOVER, then TCP segments) never drains. Called from beam_net_pump
- * after sddf_lwip_maybe_notify(). */
+ * epilogue only flushes when the PD returns from notified()/init(). When
+ * beam_net_pump runs on a cothread (a syscall stub) the root may sit blocked
+ * in seL4_Recv for a while before the next handler return, so without this
+ * flush the deferred signal would be stashed but not delivered: net_virt_tx
+ * would not be woken and the TX queue (DHCP DISCOVER, then TCP segments)
+ * would not drain promptly. Called from beam_net_pump after
+ * sddf_lwip_maybe_notify(). */
 static void beam_flush_deferred_notify(void) {
   if (microkit_have_signal) {
     microkit_have_signal = seL4_False;
@@ -151,13 +180,14 @@ static void beam_flush_deferred_notify(void) {
   }
 }
 
-/* Pump the linked lwIP stack. Under ERTS, erl_start() never returns to the
- * Microkit event loop, so notified() is dead, instead the poll/sleep syscall
- * stubs ERTS spins on (epoll_pwait, ppoll, pselect6, clock_nanosleep) call this
- * to advance lwIP's RX and flush pending TX. process_timeout is decimated: it
- * costs a timer PPC per call (sys_now) and epoll_pwait is the scheduler's hot
- * idle loop, while TCP/DHCP timers need only coarse (~100 ms) granularity.
- * No-op until net_init has run (lwip_up). */
+/* Pump the linked lwIP stack. notified() is the primary driver now that
+ * init() returns to the Microkit event loop. The poll syscall stubs
+ * (epoll_pwait, ppoll, pselect6) still call this as a latency backstop so RX
+ * enqueued while cothreads are actively running (root not yet back in the
+ * handler loop) is processed before a poll verdict. process_timeout is
+ * decimated: it costs a timer PPC per call (sys_now) and the service-timer
+ * tick in notified() already drives it at the coarse (~100 ms) granularity
+ * TCP/DHCP timers need. No-op until net_init has run (lwip_up). */
 void beam_net_pump(void) {
   static unsigned pump_count;
   if (!lwip_up) {
@@ -224,6 +254,48 @@ static void socket_smoke(void) {
   close(c);
 
   printf("SOCKET_SMOKE|PASS\n");
+}
+
+/* Cothread entry for ERTS. Spawned by beam_run() so init() can return to the
+ * Microkit event loop. erl_start() runs the emulator core loop and normally
+ * never returns. If it ever does (fatal shutdown), park the cothread rather
+ * than fall off the end. */
+static void beam_erl_entry(void) {
+  /* -MIscs 256: cap the ERTS literal super carrier at 256 MiB so it fits
+   * inside the 512 MiB beam_heap region. ERTS reserves a 1024 MiB contiguous
+   * literal carrier by default (for 64-bit literal-term addressing), which the
+   * bump allocator over beam_heap cannot satisfy. 256 MiB is ample for boot +
+   * OTP + the Gleam payload's literals. NOTE: the emulator parses allocator
+   * flags in their `-M...` form. erlexec normally translates the user-facing
+   * `+M...`. We bypass erlexec (calling erl_start directly), so we pass the
+   * `-M` form.
+   * Emulator flags come first, everything after `--` is passed to `init`
+   * (erl_prim_loader reads -root/-boot from there to find the boot script).
+   * Without the `--`, the emulator treats -root as an unknown flag and prints
+   * usage.
+   * -Bd: disable the Ctrl+C break handler (its thread otherwise select()s on
+   * the console forever, which we cannot service). After `--`, the init args
+   * erlexec normally supplies: -root, -bindir (erl_prim_loader requires the
+   * command-line -bindir, distinct from the BINDIR env var), -boot (the boot
+   * script), embedded mode. */
+  static char *argv[] = {
+      "beam",
+      "-MIscs",
+      "256",
+      "-Bd",
+      "--",
+      "-root",
+      "/",
+      "-bindir",
+      "/bin",
+      "-boot",
+      "/releases/28/start",
+      "-mode",
+      "embedded",
+      NULL,
+  };
+  erl_start(13, argv);
+  thread_park_forever();
 }
 
 static void beam_run(void) {
@@ -307,41 +379,17 @@ static void beam_run(void) {
     setenv("EMU", "beam", 1);
     setenv("PROGNAME", "beam", 1);
 
-    /* -MIscs 256: cap the ERTS literal super carrier at 256 MiB so it fits
-     * inside the 512 MiB beam_heap region. ERTS reserves a 1024 MiB
-     * contiguous literal carrier by default (for 64-bit literal-term
-     * addressing), which the bump allocator over beam_heap cannot satisfy.
-     * 256 MiB is ample for boot + OTP + the Gleam payload's literals.
-     * NOTE: the emulator parses allocator flags in their `-M...` form;
-     * erlexec normally translates the user-facing `+M...`. We bypass erlexec
-     * (calling erl_start directly), so we pass the `-M` form. */
-    /* Emulator flags come first, everything after `--` is passed to `init`
-     * (erl_prim_loader reads -root/-boot from there to find the boot script).
-     * Without the `--`, the emulator treats -root as an unknown flag and
-     * prints usage. */
-    /* -Bd: disable the Ctrl+C break handler (its thread otherwise select()s
-     * on the console forever, which we cannot service).
-     * After `--`, the init args erlexec normally supplies: -root, -bindir
-     * (erl_prim_loader requires the command-line -bindir, distinct from the
-     * BINDIR env var), -boot (the boot script), embedded mode. */
-    static char *argv[] = {
-        "beam",
-        "-MIscs",
-        "256",
-        "-Bd",
-        "--",
-        "-root",
-        "/",
-        "-bindir",
-        "/bin",
-        "-boot",
-        "/releases/28/start",
-        "-mode",
-        "embedded",
-        NULL,
-    };
     printf("Handing off to ERTS core loop...\n");
-    erl_start(13, argv);
+    /* Spawn ERTS onto a cothread instead of calling erl_start inline on the
+     * root thread. The root thread must stay free to return to Microkit's
+     * handler loop so notified() fires and drives the cothread scheduler
+     * (recv_ntfn / thread_io_wake). Running erl_start inline monopolised the
+     * root forever, which is why every idle/wait path had to busy-poll.
+     * thread_run_cothreads() runs ERTS until it first parks (all cothreads
+     * blocked), then returns so init() returns and the vCPU blocks in
+     * seL4_Recv. Boot then continues from notified(). */
+    microkit_cothread_spawn(beam_erl_entry, NULL);
+    thread_run_cothreads();
   } else {
     printf("liberts.a not linked: bring-up mode (console + clock + heap).\n");
     /* Run the socket smoke test on a cothread. init() then returns to the
@@ -367,25 +415,45 @@ void init(void) {
                     serial_config.tx.data.size, serial_config.tx.data.vaddr);
 
   beam_run();
+
+  /* ERTS runs on a cothread, so init() returns and Microkit's handler loop
+   * takes over. From now on the PD blocks in seL4_Recv when idle and
+   * notified() drives the cothread wakeups. */
+  printf("Chrysopolis: init() returned; Microkit event loop live.\n");
 }
 
 void notified(microkit_channel ch) {
+  /* The armed timeout fired: clear the mux slot so the next beam_timer_arm
+   * re-arms from scratch. Timed waiters woken by the pulse below re-arm their
+   * own remaining deadlines. */
+  if (ch == timer_config.driver_id) {
+    beam_timer_deadline = 0;
+  }
   /* Pump the linked lwIP stack on the net-RX / service-timer channels before
    * waking any cothread blocked on this channel, so a woken socket cothread
    * sees fresh RX. Gated on lwip_up so we never touch an uninitialised stack.
-   * This drives lwIP in bring-up mode, under ERTS notified() never fires
-   * (erl_start monopolises the loop) and beam_net_pump() does the pumping. */
+   * With init() returning to the event loop this now drives lwIP in BOTH
+   * modes. beam_net_pump() from the syscall stubs is only a latency backstop
+   * while cothreads are actively running. */
   if (lwip_up) {
     if (ch == timer_config.driver_id) {
       sddf_lwip_process_rx();
       sddf_lwip_process_timeout();
-      sddf_timer_set_timeout(timer_config.driver_id, NET_TIMEOUT);
+      /* Keep the service tick alive (the mux slot was cleared above, so this
+       * always arms). Sleepers with nearer deadlines shorten it. */
+      beam_timer_arm(sddf_timer_time_now(timer_config.driver_id) + NET_TIMEOUT);
     } else if (ch == net_config.rx.id) {
       sddf_lwip_process_rx();
     }
   }
-  /* Wake any cothread blocked on this channel (fs/serial/net completions). */
+  /* Wake any cothread blocked on this specific channel via wait_on_channel
+   * (e.g. console_read parked on the serial-RX channel). */
   thread_notified(ch);
+  /* Pulse the shared idle semaphore so cothreads parked in thread_io_wait()
+   * (epoll_pwait / ppoll / pselect6 / clock_nanosleep / futex) re-check their
+   * readiness. Any notification may have changed something they care about
+   * (serial input, a fired timer, socket state). */
+  thread_io_wake();
   if (lwip_up) {
     sddf_lwip_maybe_notify();
   }

--- a/src/runtime/process.c
+++ b/src/runtime/process.c
@@ -10,7 +10,7 @@
  *   - pthread_self   -> the current cothread handle
  *   - errno + pthread_key TLS -> indexed by the current cothread handle
  *     (ERTS uses pthread_key, never native __thread, so no TPIDR juggling)
- *   - locks/condvars -> yield to the cothread scheduler; ERTS wraps every
+ *   - locks/condvars -> yield to the cothread scheduler. ERTS wraps every
  *     cond_wait in a condition loop, so spurious wakeups are fine
  *
  * Cooperative scheduling: a cothread runs until it yields/blocks. ERTS's
@@ -29,6 +29,11 @@
 
 #include "rng.h" /* RNG_REALTIME_BASE_EPOCH, for the condvar deadline clock */
 
+/* Timer multiplexer (main.c): keeps the single sDDF timeout slot armed for the
+ * nearest pending deadline (absolute, monotonic ns). Timed waits arm it so a
+ * thread_io_wait() pulse is guaranteed to arrive by their deadline. */
+extern void beam_timer_arm(uint64_t deadline_ns);
+
 /* -------------------------------------------------------------------------
  * Cothread runtime
  * ------------------------------------------------------------------------- */
@@ -36,6 +41,39 @@
 
 static co_control_t co_controller;
 static int co_runtime_up;
+
+/* Idle/wakeup plumbing for the "real blocking idle" model. ERTS now runs on a
+ * spawned cothread and init() returns to the Microkit handler loop, so
+ * notified() fires and can wake cothreads that parked instead of busy-yielding.
+ *
+ *  - io_wakeup_sem: the single semaphore every idle wait blocks on
+ *    (epoll_pwait / ppoll / pselect6 / clock_nanosleep / futex / condvars).
+ *    notified() pulses it on ANY channel notification (thread_io_wake), so a
+ *    parked cothread re-checks its own readiness predicate and either proceeds
+ *    or re-parks. A cothread blocked here is NOT "ready", so when every
+ * cothread is parked the scheduler falls back to the root thread and
+ * init()/notified() returns to Microkit's seL4_Recv -> the vCPU actually blocks
+ * (~0% CPU).
+ *
+ *    A pulse must wake ALL current waiters (a serial-RX pulse must reach the
+ *    epoll waiter even if a futex waiter parked first), but
+ *    microkit_cothread_semaphore_signal wakes exactly one (the head). So
+ *    thread_io_wake bumps a generation counter and wakes the head, and each
+ *    woken waiter whose generation moved cascades the wakeup to the next
+ *    waiter before returning. Waiters that re-park during the broadcast join
+ *    at the TAIL with a fresh generation snapshot, so the cascade terminates.
+ *  - boot_idle_sem: the root thread parks here in thread_run_cothreads() to
+ *    hand control to the freshly spawned ERTS cothread. It is never signalled.
+ *    When every cothread is parked the scheduler falls back to the root
+ *    (internal_go_next's empty-queue fallback), which returns out of this wait
+ *    and lets init() return.
+ *  - park_sem: never signalled. A cothread that must block forever (ERTS's
+ *    signal-dispatcher reading a pipe that never delivers, since we have no OS
+ *    signals) parks here consuming no CPU instead of yielding forever. */
+static microkit_cothread_sem_t io_wakeup_sem;
+static microkit_cothread_sem_t boot_idle_sem;
+static microkit_cothread_sem_t park_sem;
+static unsigned io_wake_generation;
 
 /* Per-cothread pthread_key storage, indexed by cothread handle. errno is
  * left to musl (its single main-thread errno is safe here: cothreads only
@@ -68,13 +106,81 @@ void thread_init(void) {
     stacks[i] = (uintptr_t)malloc(CO_STACK_SIZE);
   }
   microkit_cothread_init(&co_controller, CO_STACK_SIZE, stacks);
+  microkit_cothread_semaphore_init(&io_wakeup_sem);
+  microkit_cothread_semaphore_init(&boot_idle_sem);
+  microkit_cothread_semaphore_init(&park_sem);
   co_runtime_up = 1;
 }
 
-/* Drive the cothread scheduler from the PD's notification handler. */
+/* Drive the cothread scheduler from the PD's notification handler: wake any
+ * cothread blocked in wait_on_channel(ch) (e.g. console_read on the serial-RX
+ * channel). Must be called from the root thread (recv_ntfn asserts this). */
 void thread_notified(microkit_channel ch) {
   if (co_runtime_up) {
     microkit_cothread_recv_ntfn(ch);
+  }
+}
+
+/* Hand control from the root thread to the spawned cothreads (ERTS + helpers)
+ * and return only once they are all parked (idle). Called from init() after
+ * spawning erl_start: the root parks on a never-signalled semaphore, so the
+ * scheduler runs the ready cothreads until every one of them blocks, at which
+ * point it falls back to the root and this returns -> init() returns to the
+ * Microkit event loop. */
+void thread_run_cothreads(void) {
+  if (co_runtime_up) {
+    microkit_cothread_semaphore_wait(&boot_idle_sem);
+  }
+}
+
+/* Park the current cothread on the shared idle semaphore until the next
+ * thread_io_wake() pulse (from notified() on any channel, or from a cothread
+ * that changed a waited-on condition). The caller MUST re-check its own
+ * predicate in a loop: pulses are broadcast, not targeted.
+ *
+ * The root thread must never park here (it must stay free to return to the
+ * Microkit event loop, and a blocked root re-queuing itself on the semaphore
+ * would corrupt its waiter list via the empty-queue root fallback), so from
+ * the root this degrades to a plain yield. */
+void thread_io_wait(void) {
+  if (!co_runtime_up || microkit_cothread_my_handle() == 0) {
+    co_yield_once();
+    return;
+  }
+  unsigned gen = io_wake_generation;
+  do {
+    microkit_cothread_semaphore_wait(&io_wakeup_sem);
+  } while (gen == io_wake_generation); /* stale latched pulse: re-park */
+  /* Broadcast cascade: wake the next parked waiter so every waiter present at
+   * the pulse re-checks. Waiters that re-parked meanwhile snapshot the new
+   * generation and simply re-park, ending the cascade. */
+  if (!microkit_cothread_semaphore_is_queue_empty(&io_wakeup_sem)) {
+    microkit_cothread_semaphore_signal(&io_wakeup_sem);
+  }
+}
+
+/* Wake every cothread parked in thread_io_wait(). Called from notified() (root)
+ * on each notification and from wakers (futex FUTEX_WAKE, cond_signal, the
+ * poll-wakeup pipe write). If nobody is waiting the pulse is latched by the
+ * semaphore. The next waiter consumes it, sees its generation unchanged and
+ * re-parks. */
+void thread_io_wake(void) {
+  if (co_runtime_up) {
+    io_wake_generation++;
+    microkit_cothread_semaphore_signal(&io_wakeup_sem);
+  }
+}
+
+/* Park the current cothread forever (never woken). For blocking reads on fds
+ * that will never deliver (ERTS's signal-dispatcher thread on the signal pipe:
+ * there are no OS signals here). Consumes no CPU, unlike a yield loop. */
+void thread_park_forever(void) {
+  for (;;) {
+    if (co_runtime_up) {
+      microkit_cothread_semaphore_wait(&park_sem);
+    } else {
+      seL4_Yield();
+    }
   }
 }
 
@@ -88,7 +194,7 @@ void thread_notified(microkit_channel ch) {
 #define FSUB(p, v) __atomic_fetch_sub((p), (v), __ATOMIC_ACQ_REL)
 
 /* -------------------------------------------------------------------------
- * pthread_mutex (cooperative spin-yield; recursive supported)
+ * pthread_mutex (cooperative spin-yield, recursive supported)
  * ------------------------------------------------------------------------- */
 int pthread_mutex_init(pthread_mutex_t *m, const pthread_mutexattr_t *attr) {
   for (int i = 0; i < 10; i++) {
@@ -162,7 +268,7 @@ int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type) {
 }
 
 /* -------------------------------------------------------------------------
- * pthread_cond: __i[0] is a signal counter; cond_wait yields for spurious
+ * pthread_cond: __i[0] is a signal counter. cond_wait yields for spurious
  * wakeups (ERTS re-checks its predicate), letting other cothreads run.
  * ------------------------------------------------------------------------- */
 int pthread_cond_init(pthread_cond_t *c, const pthread_condattr_t *attr) {
@@ -178,24 +284,29 @@ int pthread_cond_destroy(pthread_cond_t *c) {
   return 0;
 }
 
+/* Signal/broadcast bump the counter AND pulse the idle waiters: cond waiters
+ * park in thread_io_wait() (instead of the old busy-yield loop), so without the
+ * pulse a signal from another cothread would never wake them. */
 int pthread_cond_signal(pthread_cond_t *c) {
   FADD(&c->__u.__i[0], 1);
+  thread_io_wake();
   return 0;
 }
 
 int pthread_cond_broadcast(pthread_cond_t *c) {
   FADD(&c->__u.__i[0], 1);
+  thread_io_wake();
   return 0;
 }
 
 int pthread_cond_wait(pthread_cond_t *c, pthread_mutex_t *m) {
   int snapshot = LOAD(&c->__u.__i[0]);
   pthread_mutex_unlock(m);
-  /* Yield to let the signaller (another cothread) run. Bounded so a wait for
-   * an event that only arrives via a Microkit notification still returns
-   * (spurious) and ERTS re-polls. */
+  /* Park until a pulse (cond_signal pulses, so does any notification). Bounded
+   * so a wait whose signal path we somehow miss still returns spurious and
+   * ERTS re-checks its predicate (it wraps every cond_wait in a loop). */
   for (int i = 0; i < 64 && LOAD(&c->__u.__i[0]) == snapshot; i++) {
-    co_yield_once();
+    thread_io_wait();
   }
   pthread_mutex_lock(m);
   return 0;
@@ -219,9 +330,22 @@ int pthread_cond_timedwait(pthread_cond_t *c, pthread_mutex_t *m,
                       ? CLOCK_REALTIME
                       : CLOCK_MONOTONIC;
 
+  /* The sDDF timer lives on the monotonic timeline. Rebase a realtime deadline
+   * (epoch-offset, see rng.h) before arming, exactly like clock_nanosleep. */
+  uint64_t deadline_ns =
+      (uint64_t)abstime->tv_sec * 1000000000ull + (uint64_t)abstime->tv_nsec;
+  if (clk == CLOCK_REALTIME) {
+    uint64_t epoch_ns =
+        (RNG_REALTIME_BASE_EPOCH + rng_realtime_offset_sec) * 1000000000ull;
+    deadline_ns = deadline_ns > epoch_ns ? deadline_ns - epoch_ns : 0;
+  }
+
   struct timespec now;
   for (;;) {
-    co_yield_once();
+    /* Arm the timer so a wakeup pulse arrives by the deadline, then park
+     * until the next pulse (instead of the old busy-yield loop). */
+    beam_timer_arm(deadline_ns);
+    thread_io_wait();
     if (LOAD(&c->__u.__i[0]) != snapshot) {
       break;
     }
@@ -372,7 +496,7 @@ int pthread_once(pthread_once_t *control, void (*init_routine)(void)) {
 
 /* -------------------------------------------------------------------------
  * pthread identity, create, join (over cothreads).
- * pthread_t is `struct __pthread *`; we encode the cothread handle as
+ * pthread_t is `struct __pthread *`. We encode the cothread handle as
  * (handle + 1) so the main cothread (handle 0) is a non-NULL pthread_t.
  * ------------------------------------------------------------------------- */
 #define HANDLE_TO_PTHREAD(h) ((pthread_t)(uintptr_t)((h) + 1))
@@ -433,7 +557,7 @@ int pthread_detach(pthread_t thread) {
 
 void pthread_exit(void *retval) {
   (void)retval;
-  /* Returning from the trampoline ends the cothread; if a thread calls
+  /* Returning from the trampoline ends the cothread. If a thread calls
    * pthread_exit directly we cannot unwind its stack, so just park it by
    * yielding forever (the scheduler runs the others). */
   for (;;) {
@@ -442,7 +566,7 @@ void pthread_exit(void *retval) {
 }
 
 /* -------------------------------------------------------------------------
- * pthread_attr (stack size honoured loosely; cothread stacks are fixed)
+ * pthread_attr (stack size honoured loosely, cothread stacks are fixed)
  * ------------------------------------------------------------------------- */
 int pthread_attr_init(pthread_attr_t *attr) {
   for (int i = 0; i < 14; i++) {

--- a/src/runtime/rng.c
+++ b/src/runtime/rng.c
@@ -76,7 +76,7 @@ static inline uint64_t read_cntpct(void) {
 
 /* FNV-1a mixing constants (64-bit): a cheap, dependency-free accumulator that
  * folds the raw timing samples into the seed pool. HMAC-DRBG does the real
- * conditioning; this just packs the samples. */
+ * conditioning. This just packs the samples. */
 #define FNV64_OFFSET 0xcbf29ce484222325ull
 #define FNV64_PRIME 0x100000001b3ull
 
@@ -147,7 +147,7 @@ static size_t jitter_collect(uint8_t *buf, size_t len) {
 /*
  * Documented fallback when jitter fails its health check: a build-time constant
  * XOR the initial CNTPCT reading XOR the sDDF monotonic timer. Under normal
- * QEMU the counter/timer still advance per boot, so the seed varies; under
+ * QEMU the counter/timer still advance per boot, so the seed varies. Under
  * strict determinism it is at least defined rather than a fixed pattern.
  * Returns 32 bytes.
  */

--- a/src/runtime/rng.h
+++ b/src/runtime/rng.h
@@ -13,13 +13,13 @@
  * new PD and no QEMU device, and works on real hardware and any hypervisor
  * (jitter is the always-present source). virtio-rng and a future ARMv8.5
  * RNDR/RNDRRS source are optional *reseed* providers that slot into the same
- * rng_provider_t interface with no structural change (see issues/0.3.0-*.md).
+ * rng_provider_t interface with no structural change.
  *
  * The hot path (rng_fill) always reads the local DRBG, so it never blocks and
- * never runs dry; providers feed reseed only, and a provider that returns no
- * bytes simply skips a reseed round. This honours the erl_start()-never-returns
- * constraint (the same one that shaped fs_blocking_wait / beam_net_pump):
- * beam_server never blocks on another PD to produce randomness.
+ * never runs dry. Providers feed reseed only, and a provider that returns no
+ * bytes simply skips a reseed round. beam_server never blocks on another PD to
+ * produce randomness (a property worth keeping even now that init() returns to
+ * the event loop and blocking waits exist).
  */
 #pragma once
 
@@ -60,7 +60,7 @@ void rng_reseed_from(const rng_provider_t *provider);
  * Small and bounded (see rng.c): enough to make erlang:make_ref()/rand differ
  * across boots without making the wall clock randomly wrong by up to a year.
  * bringup.c's clock_gettime shim adds this (over the base epoch below) to
- * CLOCK_REALTIME only; CLOCK_MONOTONIC is untouched. Zero until rng_init runs.
+ * CLOCK_REALTIME only. CLOCK_MONOTONIC is untouched. Zero until rng_init runs.
  */
 extern uint32_t rng_realtime_offset_sec;
 


### PR DESCRIPTION
## Description

Makes our hacky ERTS process run a libmicrokitco co-thread.

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "- Closes #123" to auto-close the issue on merge. -->

- Closes #14 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor / cleanup

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `nix fmt` run
